### PR TITLE
Keep categories errors between form submissions

### DIFF
--- a/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/survey_results/new.html.erb
+++ b/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/survey_results/new.html.erb
@@ -16,7 +16,7 @@
 
           <div class="field">
             <label><%= t("questions.categories", scope: "decidim_hospitalet.surveys") %></label>
-            <%= form.collection_check_boxes :categories_ids, current_feature.categories, :id, Proc.new {|c| translated_attribute(c.name) } do |b| %>
+            <%= form.collection_check_boxes :categories_ids, current_feature.categories, Proc.new {|c| c.id.to_s }, Proc.new {|c| translated_attribute(c.name) } do |b| %>
               <%= b.label { b.check_box + b.text } %>
             <% end %>
           </div>


### PR DESCRIPTION
#### :tophat: What? Why?
When submitting too many categories in the survey form, the categories are not kept between submissions.

This PR solves this.

#### :pushpin: Related Issues
- Fixes #22 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None