### PR TITLE
Add index page for surveys

### DIFF
--- a/engines/decidim_hospitalet-surveys/app/controllers/decidim_hospitalet/surveys/survey_results_controller.rb
+++ b/engines/decidim_hospitalet-surveys/app/controllers/decidim_hospitalet/surveys/survey_results_controller.rb
@@ -19,7 +19,7 @@ module DecidimHospitalet
         CreateSurveyResult.call(@form) do
           on(:ok) do |survey_result|
             flash[:notice] = I18n.t("surveys.create.success", scope: "decidim_hospitalet")
-            redirect_to decidim.participatory_process_path(current_participatory_process)
+            redirect_to action: :index
           end
 
           on(:invalid) do

--- a/engines/decidim_hospitalet-surveys/app/models/decidim_hospitalet/surveys/survey_result.rb
+++ b/engines/decidim_hospitalet-surveys/app/models/decidim_hospitalet/surveys/survey_result.rb
@@ -3,7 +3,7 @@ module DecidimHospitalet
   module Surveys
     # The data store for a SurveyResult in the DecidimHospitalet::Surveys component.
     class SurveyResult < Surveys::ApplicationRecord
-      GENDERS = %w{male female}.freeze
+      GENDERS = %w{female male}.freeze
       AGE_GROUPS = [
         "0-17",
         "18-24",

--- a/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/survey_results/index.html.erb
+++ b/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/survey_results/index.html.erb
@@ -1,0 +1,21 @@
+<div class="row columns">
+  <h2 class="section-heading"><%= t(".title") %></h2>
+</div>
+<div class="row">
+  <div class="columns large-6 medium-centered">
+    <div class="card">
+      <div class="card__content">
+        <%== t('.surveys_info') %>
+        <div class="row">
+          <div class="columns medium-centered medium-7 mediumlarge-8">
+            <%= link_to action: :new do %>
+              <button class="button expanded button--sc">
+                <%= t('.answer_the_survey') %>
+              </button>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/engines/decidim_hospitalet-surveys/config/locales/ca.yml
+++ b/engines/decidim_hospitalet-surveys/config/locales/ca.yml
@@ -27,6 +27,10 @@ ca:
         working_at_scope: Treballes al barri?
         zip_code: Codi postal
       survey_results:
+        index:
+          answer_the_survey: "Respon l'enquesta"
+          surveys_info: "<p>L’Ajuntament de L’Hospitalet està impulsant el procés participatiu L’H ON dels Barris. Amb aquest procés es pretén obtenir una visió compartida amb la ciutadania sobre el posicionament i els objectius de futur dels diferents districtes i barris de la nostra ciutat.</p><p>Una de les eines que estem utilitzant en aquest procés és aquest qüestionari, en què et demanem la teva opinió sobre les prioritats de què creus que ens hem d’ocupar al teu barri els propers anys.</p>"
+          title: Enquesta
         new:
           send: Enviar enquesta
           title: Enquesta

--- a/engines/decidim_hospitalet-surveys/config/locales/es.yml
+++ b/engines/decidim_hospitalet-surveys/config/locales/es.yml
@@ -14,9 +14,11 @@ es:
         categories: 'Selecciona 4 temas que consideres que son prioritarios en tu
           barrio para los próximos 10 años:'
         city: "¿En qué municipio vives?"
-        future_ideas: Dentro de 10 años, ¿por qué te gustaría que se conociera tu
-          barrio?
+        future_ideas: Dentro de 10 años, ¿por qué te gustaría que se conociera tu barrio?
         gender: Género
+        genders:
+          female: Mujer
+          male: Hombre
         living_at_scope: "¿Vives en el barrio?"
         name: Nombre
         other_priorities: 'Otros temas que consideres prioritarios (especifícalos):'
@@ -25,6 +27,10 @@ es:
         working_at_scope: "¿Trabajas en el barrio?"
         zip_code: Código postal
       survey_results:
+        index:
+          answer_the_survey: "Responde la encuesta"
+          surveys_info: "<p>El Ayuntamiento de L’Hospitalet está impulsando el proceso participativo L’H ON dels Barris. Mediante este proceso lo que se pretende es obtener una visión compartida con la ciudadanía sobre el posicionamiento y los objetivos de futuro de los diferentes distritos y barrios que componen nuestra ciudad.</p><p>Una de las herramientas que estamos utilizando en este proceso es este cuestionario, en el que te preguntamos qué opinas sobre las prioridades de las que crees que tenemos que ocuparnos en tu barrio durante los próximos años.</p>"
+          title: Encuesta
         new:
           send: Enviar encuesta
           title: Encuesta

--- a/engines/decidim_hospitalet-surveys/lib/decidim_hospitalet/surveys/engine.rb
+++ b/engines/decidim_hospitalet-surveys/lib/decidim_hospitalet/surveys/engine.rb
@@ -8,8 +8,8 @@ module DecidimHospitalet
       isolate_namespace DecidimHospitalet::Surveys
 
       routes do
-        resources :survey_results, only: [:create, :new]
-        root to: "survey_results#new"
+        resources :survey_results, only: [:create, :new, :index]
+        root to: "survey_results#index"
       end
     end
   end

--- a/engines/decidim_hospitalet-surveys/spec/features/surveys_spec.rb
+++ b/engines/decidim_hospitalet-surveys/spec/features/surveys_spec.rb
@@ -26,6 +26,7 @@ describe "Surveys", type: :feature do
       click_link "Processos"
       click_link translated(participatory_process.title, locale: :ca)
       click_link "Enquestes"
+      click_link "Respon l'enquesta"
 
       expect(page).to have_content("Has d'iniciar sessió o bé registrar-te abans de continuar.")
     end
@@ -41,6 +42,7 @@ describe "Surveys", type: :feature do
         click_link "Processos"
         click_link translated(participatory_process.title, locale: :ca)
         click_link "Enquestes"
+        click_link "Respon l'enquesta"
 
         within ".new_survey_result" do
           select scope.name, from: :survey_result_scope_id
@@ -59,6 +61,7 @@ describe "Surveys", type: :feature do
         click_link "Processos"
         click_link translated(participatory_process.title, locale: :ca)
         click_link "Enquestes"
+        click_link "Respon l'enquesta"
 
         within ".new_survey_result" do
           expect(page).not_to have_css("option", text: scope.name)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds an index page for surveys, showing a description and a link to the actual survey.

#### :pushpin: Related Issues
- Closes #28

#### :clipboard: Subtasks
none

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/KcDD5Io.png)