### PR TITLE
Add omniauth credentials to secrets

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,8 +13,14 @@
 default: &default
   omniauth:
     facebook:
-      app_id: <%= ENV["OMNIAUTH_FACEBOOK_APP_ID"] %>
-      app_secret: <%= ENV["OMNIAUTH_FACEBOOK_APP_SECRET"] %>
+      # It must be a boolean. Remember ENV variables doesn't support booleans.
+      enabled: false
+      app_id: <%%= ENV["OMNIAUTH_FACEBOOK_APP_ID"] %>
+      app_secret: <%%= ENV["OMNIAUTH_FACEBOOK_APP_SECRET"] %>
+    twitter:
+      enabled: false
+      api_key: <%%= ENV["OMNIAUTH_TWITTER_API_KEY"] %>
+      api_secret: <%%= ENV["OMNIAUTH_TWITTER_API_SECRET"] %>
 
 development:
   <<: *default

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -10,15 +10,24 @@
 # Make sure the secrets in this file are kept private
 # if you're sharing your code publicly.
 
+default: &default
+  omniauth:
+    facebook:
+      app_id: <%= ENV["OMNIAUTH_FACEBOOK_APP_ID"] %>
+      app_secret: <%= ENV["OMNIAUTH_FACEBOOK_APP_SECRET"] %>
+
 development:
+  <<: *default
   secret_key_base: e3efe0351af320dda7a3daf90a805a68e94d093cfc57a94bf9c42f3f1732fac32dd4656f435e385f1ea7789ff5e387a6313d1db2a3b11e9dd030293158bfdc9b
 
 test:
+  <<: *default
   secret_key_base: 4a6fd36ca5634dbf42f63331b1a236a041976561ec314414d1750f33ef691dd3705ff2828a607d98bee0ba492e11281a33e736c71e959ab04c76679e74ecb564
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
+  <<: *default
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   sendgrid: <%= !ENV["SENDGRID_USERNAME"].blank? %>
   smtp_username: <%= ENV["SMTP_USERNAME"] || ENV["SENDGRID_USERNAME"] %>


### PR DESCRIPTION
#### :tophat: What? Why?

I added omniauth omniauth credentials to secrets. They must be defined as a env variables into the server.

#### :pushpin: Related Issues
- Related to https://github.com/AjuntamentdeBarcelona/decidim/pull/515

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
