### PR TITLE
Update system gem version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 before_install:
   # Repo for newer Node.js versions
   - export BUNDLE_PATH="$TRAVIS_BUILD_DIR/.bundle"
+  - gem update --system
 
 # Skip the install step
 install: true


### PR DESCRIPTION
#### :tophat: What? Why?
Builds are broken on Travis because the `gem` command is not using the latest version available. This PR updates the command manually. This was reported by me to Travis:

https://github.com/travis-ci/travis-ci/issues/7204

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None