### PR TITLE
Use carrierwave-aws instead of fog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ end
 group :production do
   gem 'rails_12factor'
   gem 'sendgrid-ruby'
-  gem 'fog-aws'
+  gem 'carrierwave-aws'
   gem 'sentry-raven'
   gem 'newrelic_rpm'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,14 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
     ast (2.3.0)
+    aws-sdk (2.7.0)
+      aws-sdk-resources (= 2.7.0)
+    aws-sdk-core (2.7.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.7.0)
+      aws-sdk-core (= 2.7.0)
+    aws-sigv4 (1.0.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -194,6 +202,9 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
+    carrierwave-aws (1.0.2)
+      aws-sdk (~> 2.0)
+      carrierwave (>= 0.7, < 2.0)
     cliver (0.3.2)
     codecov (0.1.9)
       json
@@ -237,7 +248,6 @@ GEM
       thread_safe
     equalizer (0.0.11)
     erubis (2.7.0)
-    excon (0.54.0)
     execjs (2.7.0)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
@@ -252,22 +262,6 @@ GEM
     file_validators (2.1.0)
       activemodel (>= 3.0)
       mime-types (>= 1.0)
-    fog-aws (1.1.0)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-core (1.43.0)
-      builder
-      excon (~> 0.49)
-      formatador (~> 0.2)
-    fog-json (1.0.2)
-      fog-core (~> 1.0)
-      multi_json (~> 1.10)
-    fog-xml (0.1.2)
-      fog-core
-      nokogiri (~> 1.5, >= 1.5.11)
-    formatador (0.2.5)
     foundation-rails (6.3.0.0)
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
@@ -299,7 +293,7 @@ GEM
       term-ansicolor (>= 1.3.2)
       terminal-table (>= 1.5.1)
     ice_nine (0.11.2)
-    ipaddress (0.8.3)
+    jmespath (1.3.1)
     jquery-rails (4.2.2)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -556,11 +550,11 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  carrierwave-aws
   decidim!
   decidim-dev!
   decidim_hospitalet-surveys!
   faker (~> 1.7.2)
-  fog-aws
   listen (~> 3.1.0)
   newrelic_rpm
   puma (~> 3.0)

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -11,17 +11,17 @@ end
 if Rails.env.production?
   CarrierWave.configure do |config|
     config.storage = :aws
-    config.aws_bucket = ENV.fetch('decidim-hospitalet')
-    config.aws_acl    = 'public-read'
+    config.aws_bucket = ENV.fetch("decidim-hospitalet")
+    config.aws_acl    = "public-read"
     config.aws_authenticated_url_expiration = 60 * 60 * 24 * 7
 
     config.aws_attributes = {
       expires: 1.week.from_now.httpdate,
-      cache_control: 'max-age=604800'
+      cache_control: "max-age=604800"
     }
 
     config.aws_credentials = {
-      access_key_id:     Rails.application.secrets.aws_access_key_id
+      access_key_id:     Rails.application.secrets.aws_access_key_id,
       secret_access_key: Rails.application.secrets.aws_secret_access_key,
       region:            "eu-central-1"
     }

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,23 +6,25 @@ CarrierWave.configure do |config|
   config.directory_permissions = 0o777
 end
 
-# Setup CarrierWave to use Amazon S3. Add `gem "fog-aws" to your Gemfile.
+# Setup CarrierWave to use Amazon S3. Add `gem "carrierwave-aws" to your Gemfile.
 #
 if Rails.env.production?
-  require 'carrierwave/storage/fog'
-
   CarrierWave.configure do |config|
-    config.storage = :fog
-    config.fog_provider = 'fog/aws'                                             # required
-    config.fog_credentials = {
-      provider:              'AWS',                                             # required
-      aws_access_key_id:     Rails.application.secrets.aws_access_key_id,       # required
-      aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,   # required
-      host:                  "s3.eu-central-1.amazonaws.com",
-      region:                "eu-central-1"                                     # optional, defaults to 'us-east-1'
+    config.storage = :aws
+    config.aws_bucket = ENV.fetch('decidim-hospitalet')
+    config.aws_acl    = 'public-read'
+    config.aws_authenticated_url_expiration = 60 * 60 * 24 * 7
+
+    config.aws_attributes = {
+      expires: 1.week.from_now.httpdate,
+      cache_control: 'max-age=604800'
     }
-    config.fog_directory  = "decidim-hospitalet"                                # required
-    config.fog_attributes = { 'Cache-Control' => "max-age=#{365.day.to_i}" }    # optional, defaults to {}
+
+    config.aws_credentials = {
+      access_key_id:     Rails.application.secrets.aws_access_key_id
+      secret_access_key: Rails.application.secrets.aws_secret_access_key,
+      region:            "eu-central-1"
+    }
   end
 else
   CarrierWave.configure do |config|


### PR DESCRIPTION
#### :tophat: What? Why?
This uses carrierwave-aws instead of fog in order to prevent  unnecessary `HEAD` requests to s3.

#### :pushpin: Related Issues
Someone complained about this on carrierwave/fog but didn't get an answer:
https://github.com/carrierwaveuploader/carrierwave/issues/1655

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/pp1JcdZJEZssg/giphy.gif)
