### PR TITLE
Add newsletter notifications field to user registrations form

### DIFF
--- a/app/views/decidim/devise/registrations/new.html.erb
+++ b/app/views/decidim/devise/registrations/new.html.erb
@@ -38,7 +38,15 @@
                 <%= f.password_field :password_confirmation %>
               </div>
 
+              <p class="lopd-text">
+                <%= strip_tags translated_attribute(terms_and_conditions_page.content) %>
+              </p>
+
               <fieldset>
+                <div class="field">
+                  <%= f.check_box :newsletter_notifications, label: t(".newsletter_notifications") %>
+                </div>
+
                 <div class="field">
                   <%= f.check_box :tos_agreement, label: t(".tos_agreement", link: link_to(t(".terms"), page_path("terms-and-conditions"))) %>
                 </div>


### PR DESCRIPTION
#### :tophat: What? Why?

We are overriding the default `registrations#new` template that doesn't contain the `newsletters_notification` field.

#### :pushpin: Related Issues
- Fixes #98 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None