### PR TITLE
Add author to survey results in admin section

### DIFF
--- a/db/migrate/20170207102712_add_author_to_survey_results.decidim_hospitalet_surveys.rb
+++ b/db/migrate/20170207102712_add_author_to_survey_results.decidim_hospitalet_surveys.rb
@@ -1,0 +1,8 @@
+# This migration comes from decidim_hospitalet_surveys (originally 20170207101556)
+class AddAuthorToSurveyResults < ActiveRecord::Migration[5.0]
+  def change
+    change_table :decidim_hospitalet_surveys_survey_results do |t|
+      t.references :decidim_author, index: { name: "index_decidim_hospitalet_surveys_on_author_id" }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170206202135) do
+ActiveRecord::Schema.define(version: 20170207102712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -148,6 +148,8 @@ ActiveRecord::Schema.define(version: 20170206202135) do
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.boolean  "created_by_admin",    default: false
+    t.integer  "decidim_author_id"
+    t.index ["decidim_author_id"], name: "index_decidim_hospitalet_surveys_on_author_id", using: :btree
     t.index ["decidim_feature_id", "decidim_user_id", "decidim_scope_id"], name: "index_unique_user_feaeture_scope_for_surveys", unique: true, where: "(decidim_user_id IS NOT NULL)", using: :btree
     t.index ["decidim_feature_id"], name: "index_decidim_hospitalet_surveys_on_feature_id", using: :btree
     t.index ["decidim_scope_id"], name: "index_decidim_hospitalet_surveys_on_scope_id", using: :btree

--- a/engines/decidim_hospitalet-surveys/app/commands/decidim_hospitalet/surveys/admin/create_survey_result.rb
+++ b/engines/decidim_hospitalet-surveys/app/commands/decidim_hospitalet/surveys/admin/create_survey_result.rb
@@ -46,6 +46,7 @@ module DecidimHospitalet
             phone: form.phone,
             selected_categories: form.categories.map(&:id),
             created_by_admin: true,
+            author: form.current_user,
             scope: form.scope,
             user: user,
             feature: form.current_feature

--- a/engines/decidim_hospitalet-surveys/app/models/decidim_hospitalet/surveys/survey_result.rb
+++ b/engines/decidim_hospitalet-surveys/app/models/decidim_hospitalet/surveys/survey_result.rb
@@ -3,6 +3,8 @@ module DecidimHospitalet
   module Surveys
     # The data store for a SurveyResult in the DecidimHospitalet::Surveys component.
     class SurveyResult < Surveys::ApplicationRecord
+      include Decidim::Authorable
+
       GENDERS = %w(female male).freeze
       AGE_GROUPS = [
         "0-17",

--- a/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/admin/survey_results/index.html.erb
+++ b/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/admin/survey_results/index.html.erb
@@ -10,6 +10,7 @@
       <th><%= t("models.survey_result.fields.scope_name", scope: "decidim_hospitalet.survey_results") %></th>
       <th><%= t("models.survey_result.fields.categories", scope: "decidim_hospitalet.survey_results") %></th>
       <th><%= t("models.survey_result.fields.created_by_admin", scope: "decidim_hospitalet.survey_results") %></th>
+      <th><%= t("models.survey_result.fields.author", scope: "decidim_hospitalet.survey_results") %></th>
       <th class="actions"><%= t("actions.title", scope: "decidim_hospitalet.survey_results") %></th>
     </tr>
   </thead>
@@ -28,6 +29,11 @@
         </td>
         <td>
           <%= humanize_boolean survey_result.created_by_admin? %>
+        </td>
+        <td>
+          <% if survey_result.author.present? %>
+            <%= survey_result.author.name %>
+          <% end %>
         </td>
         <td class="actions">
           <%= link_to t("actions.edit", scope: "decidim_hospitalet.survey_results"), edit_survey_result_path(survey_result) if can? :update, current_feature %>

--- a/engines/decidim_hospitalet-surveys/config/locales/ca.yml
+++ b/engines/decidim_hospitalet-surveys/config/locales/ca.yml
@@ -19,6 +19,7 @@ ca:
       models:
         survey_result:
           fields:
+            author: Autor
             categories: Categories
             created_by_admin: Creat per administrador
             scope_name: Àmbit

--- a/engines/decidim_hospitalet-surveys/config/locales/es.yml
+++ b/engines/decidim_hospitalet-surveys/config/locales/es.yml
@@ -19,6 +19,7 @@ es:
       models:
         survey_result:
           fields:
+            author: Autor
             categories: Categorías
             created_by_admin: Creado por administrador
             scope_name: Ámbito

--- a/engines/decidim_hospitalet-surveys/db/migrate/20170207101556_add_author_to_survey_results.rb
+++ b/engines/decidim_hospitalet-surveys/db/migrate/20170207101556_add_author_to_survey_results.rb
@@ -1,0 +1,7 @@
+class AddAuthorToSurveyResults < ActiveRecord::Migration[5.0]
+  def change
+    change_table :decidim_hospitalet_surveys_survey_results do |t|
+      t.references :decidim_author, index: { name: "index_decidim_hospitalet_surveys_on_author_id" }
+    end
+  end
+end

--- a/engines/decidim_hospitalet-surveys/spec/commands/decidim_hospitalet/surveys/admin/create_survey_result_spec.rb
+++ b/engines/decidim_hospitalet-surveys/spec/commands/decidim_hospitalet/surveys/admin/create_survey_result_spec.rb
@@ -11,6 +11,7 @@ module DecidimHospitalet
           let(:feature) { create(:feature, participatory_process: participatory_process) }
           let(:proposals_feature) { create(:proposal_feature, participatory_process: participatory_process) }
           let(:category) { create :category, participatory_process: participatory_process }
+          let(:admin) { create(:user, :admin, organization: organization) }
           let(:user) { create(:user, organization: organization) }
           let(:email) { nil }
           let(:scope) { create(:scope, organization: organization) }
@@ -47,7 +48,8 @@ module DecidimHospitalet
               proposal_scope_id_2: nil,
               proposal_scope_id_3: nil,
               proposals_feature: proposals_feature,
-              scope: scope
+              scope: scope,
+              current_user: admin
             )
           end
           let(:subject) { described_class.new(form) }
@@ -81,6 +83,16 @@ module DecidimHospitalet
               expect do
                 subject.call
               end.to change { SurveyResult.count }.by(1)
+            end
+
+            it "sets the created_by_admin flag" do
+              subject.call
+              expect(SurveyResult.last.created_by_admin).to be_truthy
+            end
+
+            it "sets the author association to the current user" do
+              subject.call
+              expect(SurveyResult.last.author).to eq(admin)
             end
 
             it "does not create a new user" do

--- a/engines/decidim_hospitalet-surveys/spec/shared/manage_surveys_examples.rb
+++ b/engines/decidim_hospitalet-surveys/spec/shared/manage_surveys_examples.rb
@@ -40,6 +40,7 @@ RSpec.shared_examples "manage surveys" do
 
       within "table" do
         expect(page).to have_selector(".tabs-panel tbody tr", count: 2)
+        expect(page).to have_content user.name
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

I included the `Decidim::Authorable` to the `SurveyResult`. Then the survey is created in the admin section the author is stored and visible in the table.

#### :pushpin: Related Issues
- Implements #91 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/22687492/9ed8f97c-ed28-11e6-83eb-6b6dd52d539a.png)

#### :ghost: GIF
![](https://media.giphy.com/media/DvyLQztQwmyAM/giphy.gif)
