### PR TITLE
Add Export CSV action to surveys admin

### DIFF
--- a/engines/decidim_hospitalet-surveys/app/controllers/decidim_hospitalet/surveys/admin/survey_results_controller.rb
+++ b/engines/decidim_hospitalet-surveys/app/controllers/decidim_hospitalet/surveys/admin/survey_results_controller.rb
@@ -6,6 +6,17 @@ module DecidimHospitalet
       class SurveyResultsController < Admin::ApplicationController
         helper_method :survey_results, :available_scopes, :proposals_feature
 
+        def index
+          respond_to do |format|
+            format.html
+            format.csv do
+              send_data(SurveyCSVPresenter.new(survey_results).to_data,
+                      type: "text/csv; charset=utf-8; header=present",
+                      filename: "survey_results_#{Time.now.to_s(:iso8601)}.csv")
+            end
+          end
+        end
+
         def new
           @form = form(SurveyResultForm).instance
         end

--- a/engines/decidim_hospitalet-surveys/app/presenters/decidim_hospitalet/surveys/survey_csv_presenter.rb
+++ b/engines/decidim_hospitalet-surveys/app/presenters/decidim_hospitalet/surveys/survey_csv_presenter.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'csv'
+
+module DecidimHospitalet
+  module Surveys
+    # Presenter class to render surveys as a csv
+    class SurveyCSVPresenter
+      COMMON_FIELDS = [
+        :other_priorities,
+        :future_ideas,
+        :gender,
+        :age_group,
+        :zip_code,
+        :living_at_scope,
+        :city,
+        :name,
+        :phone
+      ]
+
+      def initialize(surveys)
+        @surveys = surveys
+      end
+
+      def to_data
+        headers + fields
+      end
+
+      private
+
+      def headers
+        CSV.generate_line(
+          [I18n.t("decidim_hospitalet.surveys.questions.categories")].concat(
+            COMMON_FIELDS.map do |field|
+              I18n.t("decidim_hospitalet.surveys.questions.#{field}")
+            end
+          )
+        )
+      end
+
+      def fields
+        @surveys.map do |survey|
+          CSV.generate_line(
+            [survey.categories.map {|c| c.name[I18n.locale.to_s] }.join(";")].concat(
+              COMMON_FIELDS.map { |field| survey.send(field) }
+            )
+          )
+        end.join
+      end
+    end
+  end
+end

--- a/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/admin/survey_results/index.html.erb
+++ b/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/admin/survey_results/index.html.erb
@@ -2,6 +2,7 @@
 
 <div class="actions title">
   <%= link_to t("actions.new", scope: "decidim_hospitalet.survey_results", name: t("models.survey_result.name", scope: "decidim_hospitalet.survey_results.admin")), new_survey_result_path, class: 'new' if can? :manage, current_feature %>
+  | <%= link_to t("actions.export_csv", scope: "decidim_hospitalet.survey_results.admin"), survey_results_path(format: :csv) %>
 </div>
 
 <table class="stack">

--- a/engines/decidim_hospitalet-surveys/config/locales/ca.yml
+++ b/engines/decidim_hospitalet-surveys/config/locales/ca.yml
@@ -13,6 +13,8 @@ ca:
         new: Nova %{name}
         title: Accions
       admin:
+        actions:
+          export_csv: Export csv
         models:
           survey_result:
             name: Resposta d'enquesta
@@ -52,8 +54,7 @@ ca:
         success: La teva resposta s'ha enviat correctament
       questions:
         age_group: Edat
-        categories: 'Selecciona els 4 temes que trobis que són prioritaris en el teu
-          barri per als propers 10 anys:'
+        categories: 'Selecciona els 4 temes que trobis que són prioritaris en el teu barri per als propers 10 anys:'
         city: A quin municipi vius?
         email: Correu electrònic
         email_hint: Si omples aquest camp, es convidarà l'usuari a la plataforma i

--- a/engines/decidim_hospitalet-surveys/config/locales/ca.yml
+++ b/engines/decidim_hospitalet-surveys/config/locales/ca.yml
@@ -14,7 +14,7 @@ ca:
         title: Accions
       admin:
         actions:
-          export_csv: Export csv
+          export_csv: Exportar CSV
         models:
           survey_result:
             name: Resposta d'enquesta

--- a/engines/decidim_hospitalet-surveys/config/locales/es.yml
+++ b/engines/decidim_hospitalet-surveys/config/locales/es.yml
@@ -13,6 +13,8 @@ es:
         new: Nueva %{name}
         title: Acciones
       admin:
+        actions:
+          export_csv: Export csv
         models:
           survey_result:
             name: Respuesta de encuesta

--- a/engines/decidim_hospitalet-surveys/config/locales/es.yml
+++ b/engines/decidim_hospitalet-surveys/config/locales/es.yml
@@ -14,7 +14,7 @@ es:
         title: Acciones
       admin:
         actions:
-          export_csv: Export csv
+          export_csv: Exportar CSV
         models:
           survey_result:
             name: Respuesta de encuesta

--- a/engines/decidim_hospitalet-surveys/spec/presenters/decidim_hospitalet/surveys/survey_csv_presenter_spec.rb
+++ b/engines/decidim_hospitalet-surveys/spec/presenters/decidim_hospitalet/surveys/survey_csv_presenter_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module DecidimHospitalet
+  module Surveys
+
+    describe SurveyCSVPresenter do
+      let(:current_feature) { create :surveys_feature }
+      let(:surveys) { create_list(:survey_result, 3, feature: current_feature) }
+
+      subject { described_class.new(surveys) }
+
+      context "#to_data" do
+        let(:data) { subject.to_data }
+        let(:headers) { data.split("\n").first }
+
+        it "includes the headers" do
+          expect(headers).to include("Selecciona els 4 temes que trobis que són prioritaris en el teu barri per als propers 10 anys:")
+        end
+
+        it "includes the surveys data" do
+          surveys.each do |survey|
+            expect(data).to include("#{survey.categories.map { |c| c.name["ca"] }.join(';')}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/decidim_hospitalet-surveys/spec/shared/manage_surveys_examples.rb
+++ b/engines/decidim_hospitalet-surveys/spec/shared/manage_surveys_examples.rb
@@ -100,7 +100,7 @@ RSpec.shared_examples "manage surveys" do
 
     it "downloads a csv file with the data" do
       visit current_path
-      click_link "Export csv"
+      click_link "Exportar CSV"
       expect(page.response_headers["Content-Disposition"]).to match(/filename=\"survey_results([^.]*).csv\"/)
     end
   end

--- a/engines/decidim_hospitalet-surveys/spec/shared/manage_surveys_examples.rb
+++ b/engines/decidim_hospitalet-surveys/spec/shared/manage_surveys_examples.rb
@@ -94,4 +94,14 @@ RSpec.shared_examples "manage surveys" do
       end
     end
   end
+
+  context "exporting the survey results" do
+    let!(:surveys) { create_list(:survey_result, 3, feature: current_feature) }
+
+    it "downloads a csv file with the data" do
+      visit current_path
+      click_link "Export csv"
+      expect(page.response_headers["Content-Disposition"]).to match(/filename=\"survey_results([^.]*).csv\"/)
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

As an admin I should be able to export the surveys data as a csv.

#### :pushpin: Related Issues
- Implements #92 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/22694914/4287b9a8-ed49-11e6-8ca7-d991abba4491.png)

#### :ghost: GIF
![](https://media.giphy.com/media/13mLwGra9bNEKQ/giphy.gif)
