### PR TITLE
Fix form errors

### DIFF
--- a/engines/decidim_hospitalet-surveys/app/forms/decidim_hospitalet/surveys/admin/survey_result_form.rb
+++ b/engines/decidim_hospitalet-surveys/app/forms/decidim_hospitalet/surveys/admin/survey_result_form.rb
@@ -21,8 +21,8 @@ module DecidimHospitalet
         attribute :phone, String
         attribute :email, String
 
-        validates :scope, presence: true
-        validates :categories, length: { minimum: 1, maximum: 4 }
+        validates :scope, :scope_id, presence: true
+        validates :categories, :categories_ids, length: { minimum: 1, maximum: 4 }
         validates :age_group, inclusion: { in: SurveyResult::AGE_GROUPS }, allow_blank: true
         validates :gender, inclusion: { in: SurveyResult::GENDERS }, allow_blank: true
         validates :city, inclusion: { in: Towns::TOWNS.keys }, allow_blank: true

--- a/engines/decidim_hospitalet-surveys/app/forms/decidim_hospitalet/surveys/survey_form.rb
+++ b/engines/decidim_hospitalet-surveys/app/forms/decidim_hospitalet/surveys/survey_form.rb
@@ -18,8 +18,8 @@ module DecidimHospitalet
       attribute :authorize_lopd, Boolean
       attribute :city, String
 
-      validates :scope, presence: true
-      validates :categories, length: { minimum: 1, maximum: 4 }
+      validates :scope, :scope_id, presence: true
+      validates :categories, :categories_ids, length: { minimum: 1, maximum: 4 }
       validates :age_group, inclusion: { in: SurveyResult::AGE_GROUPS }, allow_blank: true
       validates :gender, inclusion: { in: SurveyResult::GENDERS }, allow_blank: true
       validates :city, inclusion: { in: Towns::TOWNS.keys }, allow_blank: true

--- a/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/admin/survey_results/new.html.erb
+++ b/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/admin/survey_results/new.html.erb
@@ -1,6 +1,6 @@
 <h3><%= t ".title" %></h3>
 
-<%= form_for(@form) do |f| %>
+<%= decidim_form_for(@form) do |f| %>
   <%= render partial: 'form', object: f %>
 
   <div class="field">

--- a/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/survey_results/_form.html.erb
+++ b/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/survey_results/_form.html.erb
@@ -3,8 +3,8 @@
 </div>
 
 <div class="field">
-  <label><%= t("questions.categories", scope: "decidim_hospitalet.surveys") %></label>
-  <%= form.collection_check_boxes :categories_ids, current_feature.categories, Proc.new {|c| c.id.to_s }, Proc.new {|c| translated_attribute(c.name) } do |b| %>
+  <%= form.label(:categories_ids, t("questions.categories", scope: "decidim_hospitalet.surveys")) %>
+  <%= form.collection_check_boxes :categories_ids, current_feature.categories, Proc.new {|c| c.id.to_s }, Proc.new {|c| translated_attribute(c.name) }, include_hidden: false do |b| %>
     <%= b.label { b.check_box + b.text } %>
   <% end %>
 </div>

--- a/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/survey_results/new.html.erb
+++ b/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/survey_results/new.html.erb
@@ -5,7 +5,7 @@
   <div class="columns large-6 medium-centered">
     <div class="card">
       <div class="card__content">
-        <%= form_for(@form) do |form| %>
+        <%= decidim_form_for(@form) do |form| %>
           <%= render partial: "form", locals: { form: form } %>
 
           <div class="field">


### PR DESCRIPTION
#### :tophat: What? Why?
fixes a bug that prevented errors from showing in certain form fields. Also fixes how errors are displayed for single check boxes fields.

Needs to update `decidim` after https://github.com/AjuntamentdeBarcelona/decidim/pull/944 is merged.

#### :pushpin: Related Issues
- Fixes #107 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
`collection_check_boxes:
![](https://i.imgur.com/oSmyIkH.png)

Single `check_box`es:
![Description](https://i.imgur.com/q6A44dc.png)