### PR TITLE
Use global scope for survey proposals

### DIFF
--- a/engines/decidim_hospitalet-surveys/app/commands/decidim_hospitalet/surveys/admin/create_survey_result.rb
+++ b/engines/decidim_hospitalet-surveys/app/commands/decidim_hospitalet/surveys/admin/create_survey_result.rb
@@ -57,14 +57,14 @@ module DecidimHospitalet
           return unless form.proposals_feature
 
           [
-            build_proposal(form.proposal_title_0, form.proposal_description_0, form.proposal_scope_id_0),
-            build_proposal(form.proposal_title_1, form.proposal_description_1, form.proposal_scope_id_1),
-            build_proposal(form.proposal_title_2, form.proposal_description_2, form.proposal_scope_id_2),
-            build_proposal(form.proposal_title_3, form.proposal_description_3, form.proposal_scope_id_3)
+            build_proposal(form.proposal_title_0, form.proposal_description_0),
+            build_proposal(form.proposal_title_1, form.proposal_description_1),
+            build_proposal(form.proposal_title_2, form.proposal_description_2),
+            build_proposal(form.proposal_title_3, form.proposal_description_3)
           ].compact.map(&:save!)
         end
 
-        def build_proposal(title, description, scope_id)
+        def build_proposal(title, description)
           return unless title.present? || description.present?
 
           Decidim::Proposals::Proposal.new(
@@ -72,7 +72,7 @@ module DecidimHospitalet
             body: description,
             author: user,
             feature: form.proposals_feature,
-            decidim_scope_id: scope_id
+            scope: form.scope
           )
         end
 

--- a/engines/decidim_hospitalet-surveys/app/forms/decidim_hospitalet/surveys/admin/survey_result_form.rb
+++ b/engines/decidim_hospitalet-surveys/app/forms/decidim_hospitalet/surveys/admin/survey_result_form.rb
@@ -30,7 +30,6 @@ module DecidimHospitalet
         4.times do |index|
           attribute :"proposal_title_#{index}", String
           attribute :"proposal_description_#{index}", String
-          attribute :"proposal_scope_id_#{index}", String
 
           validates :"proposal_title_#{index}", presence: true, if: proc { |m| m.send("proposal_description_#{index}").present? }
           validates :"proposal_description_#{index}", presence: true, if: proc { |m| m.send("proposal_title_#{index}").present? }

--- a/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/admin/survey_results/new.html.erb
+++ b/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/admin/survey_results/new.html.erb
@@ -19,10 +19,6 @@
       <div class="field">
         <%= f.text_area :"proposal_description_#{i}", label: t("questions.proposal_description", scope: "decidim_hospitalet.surveys"), rows: 10 %>
       </div>
-
-      <div class="field">
-        <%= f.collection_select :"proposal_scope_id_#{i}", @form.scopes, :id, :name, include_blank: true, label: t("questions.proposal_scope", scope: "decidim_hospitalet.surveys") %>
-      </div>
     <% end %>
   <% end %>
 

--- a/engines/decidim_hospitalet-surveys/spec/commands/decidim_hospitalet/surveys/admin/create_survey_result_spec.rb
+++ b/engines/decidim_hospitalet-surveys/spec/commands/decidim_hospitalet/surveys/admin/create_survey_result_spec.rb
@@ -42,10 +42,6 @@ module DecidimHospitalet
               proposal_description_1: "Awesome description 1",
               proposal_description_2: nil,
               proposal_description_3: nil,
-              proposal_scope_id_0: scope.id,
-              proposal_scope_id_1: scope.id,
-              proposal_scope_id_2: nil,
-              proposal_scope_id_3: nil,
               proposals_feature: proposals_feature,
               scope: scope,
               current_user: admin
@@ -125,7 +121,7 @@ module DecidimHospitalet
             describe "with related proposals" do
               it { is_expected.to broadcast(:ok) }
 
-              context "when no propsoals featuer is present" do
+              context "when no proposals feature is present" do
                 let(:proposals_feature) { nil }
 
                 it "creates the proposals" do
@@ -139,6 +135,12 @@ module DecidimHospitalet
                 expect do
                   subject.call
                 end.to change(Decidim::Proposals::Proposal, :count).by(2)
+              end
+
+              it "sets the global scope for those proposals" do
+                subject.call
+                ids = Decidim::Proposals::Proposal.pluck(:decidim_scope_id)
+                expect(ids).to match_array [scope.id, scope.id]
               end
 
               context "when not creating a user" do


### PR DESCRIPTION
#### :tophat: What? Why?
Proposals created when an admin fills a survey result should use the proposal scope, instead of having a single scope each one.

#### :pushpin: Related Issues
- Fixes #115 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/qVJCyZN.png)