### PR TITLE
Use L'Hospitalet as default city in survey form

### DIFF
--- a/engines/decidim_hospitalet-surveys/app/helpers/decidim_hospitalet/surveys/surveys_helper.rb
+++ b/engines/decidim_hospitalet-surveys/app/helpers/decidim_hospitalet/surveys/surveys_helper.rb
@@ -21,6 +21,10 @@ module DecidimHospitalet
       def survey_towns
         DecidimHospitalet::Surveys::Towns::TOWNS.map { |id, name| [name, id] }
       end
+
+      def survey_default_town
+        DecidimHospitalet::Surveys::Towns::DEFAULT_TOWN_ID
+      end
     end
   end
 end

--- a/engines/decidim_hospitalet-surveys/app/services/decidim_hospitalet/surveys/towns.rb
+++ b/engines/decidim_hospitalet-surveys/app/services/decidim_hospitalet/surveys/towns.rb
@@ -2,8 +2,13 @@
 # frozen_string_literal: true
 module DecidimHospitalet
   module Surveys
-    # A form object to be used when public users want to anser a survey.
+    # A helper class that encapsulates some of Catalonia's cities and towns
+    # so that they can be shown in a dropdown, ordered alphabetically not
+    # considering articles.
     class Towns
+      # That's L'Hospitalet
+      DEFAULT_TOWN_ID = "810170005"
+
       TOWNS = {
         "800180001" => "Abrera",
         "800230008" => "Aguilar de Segarra",

--- a/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/survey_results/_form.html.erb
+++ b/engines/decidim_hospitalet-surveys/app/views/decidim_hospitalet/surveys/survey_results/_form.html.erb
@@ -38,5 +38,5 @@
 </div>
 
 <div class="field">
-  <%= form.select :city, survey_towns, include_blank: true, label: t("questions.city", scope: "decidim_hospitalet.surveys") %>
+  <%= form.select :city, survey_towns, include_blank: true, label: t("questions.city", scope: "decidim_hospitalet.surveys"), selected: @form.city || survey_default_town %>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Sets L'Hospitalet to the default value for cities dropdown, both in admin and public pages.

#### :pushpin: Related Issues
- Fixes #118

#### :clipboard: Subtasks
None
