### PR TITLE
Add fake user to fill proposals from surveys without email.

### DIFF
--- a/db/migrate/20170223133253_add_anonymous_user_and_modify_existing_proposals.rb
+++ b/db/migrate/20170223133253_add_anonymous_user_and_modify_existing_proposals.rb
@@ -1,0 +1,17 @@
+class AddAnonymousUserAndModifyExistingProposals < ActiveRecord::Migration[5.0]
+  def change
+    user = Decidim::User.create!(
+      {
+        name:"Enquesta/Encuesta",
+        password: "decidim123456",
+        password_confirmation: "decidim123456",
+        email: "enquestes@lhon-participa.cat",
+        tos_agreement: "1",
+        organization: Decidim::Organization.first,
+        confirmed_at: Time.current
+      }
+    )
+
+    Decidim::Proposals::Proposal.where(decidim_author_id: nil).update_all(decidim_author_id: user.id)
+  end
+end

--- a/db/migrate/20170223133253_add_anonymous_user_and_modify_existing_proposals.rb
+++ b/db/migrate/20170223133253_add_anonymous_user_and_modify_existing_proposals.rb
@@ -1,5 +1,6 @@
 class AddAnonymousUserAndModifyExistingProposals < ActiveRecord::Migration[5.0]
   def change
+    password = SecureRandom.base64(16)
     organization = Decidim::Organization.first
     user = Decidim::User.where(
         email: "enquestes@lhon-participa.cat",
@@ -7,8 +8,8 @@ class AddAnonymousUserAndModifyExistingProposals < ActiveRecord::Migration[5.0]
       ).first || Decidim::User.create!(
       {
         name: "Enquesta / Encuesta",
-        password: "decidim123456",
-        password_confirmation: "decidim123456",
+        password: password,
+        password_confirmation: password,
         email: "enquestes@lhon-participa.cat",
         tos_agreement: "1",
         organization: organization,

--- a/db/migrate/20170223133253_add_anonymous_user_and_modify_existing_proposals.rb
+++ b/db/migrate/20170223133253_add_anonymous_user_and_modify_existing_proposals.rb
@@ -2,7 +2,7 @@ class AddAnonymousUserAndModifyExistingProposals < ActiveRecord::Migration[5.0]
   def change
     user = Decidim::User.create!(
       {
-        name:"Enquesta/Encuesta",
+        name:"Enquesta / Encuesta",
         password: "decidim123456",
         password_confirmation: "decidim123456",
         email: "enquestes@lhon-participa.cat",

--- a/db/migrate/20170223133253_add_anonymous_user_and_modify_existing_proposals.rb
+++ b/db/migrate/20170223133253_add_anonymous_user_and_modify_existing_proposals.rb
@@ -1,13 +1,17 @@
 class AddAnonymousUserAndModifyExistingProposals < ActiveRecord::Migration[5.0]
   def change
-    user = Decidim::User.create!(
+    organization = Decidim::Organization.first
+    user = Decidim::User.where(
+        email: "enquestes@lhon-participa.cat",
+        organization: organization
+      ).first || Decidim::User.create!(
       {
-        name:"Enquesta / Encuesta",
+        name: "Enquesta / Encuesta",
         password: "decidim123456",
         password_confirmation: "decidim123456",
         email: "enquestes@lhon-participa.cat",
         tos_agreement: "1",
-        organization: Decidim::Organization.first,
+        organization: organization,
         confirmed_at: Time.current
       }
     )

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170223093816) do
+ActiveRecord::Schema.define(version: 20170223133253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -75,3 +75,18 @@ Decidim::Feature.where(manifest_name: :hospitalet_surveys).find_each do |feature
     )
   end
 end
+
+Decidim::User.where(
+    email: "enquestes@lhon-participa.cat",
+    organization: organization,
+  ).first || Decidim::User.create!(
+  {
+    name: "Enquesta / Encuesta",
+    password: "decidim123456",
+    password_confirmation: "decidim123456",
+    email: "enquestes@lhon-participa.cat",
+    tos_agreement: "1",
+    organization: organization,
+    confirmed_at: Time.current
+  }
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,6 +14,7 @@ Decidim.seed!
 
 organization = Decidim::Organization.first
 participatory_process = Decidim::ParticipatoryProcess.published.promoted.first
+password = SecureRandom.base64(16)
 
 puts "Deleting default L'Hospitalet scopes..."
 organization.scopes.destroy_all
@@ -82,8 +83,8 @@ Decidim::User.where(
   ).first || Decidim::User.create!(
   {
     name: "Enquesta / Encuesta",
-    password: "decidim123456",
-    password_confirmation: "decidim123456",
+    password: password,
+    password_confirmation: password,
     email: "enquestes@lhon-participa.cat",
     tos_agreement: "1",
     organization: organization,

--- a/engines/decidim_hospitalet-surveys/app/commands/decidim_hospitalet/surveys/admin/create_survey_result.rb
+++ b/engines/decidim_hospitalet-surveys/app/commands/decidim_hospitalet/surveys/admin/create_survey_result.rb
@@ -77,7 +77,7 @@ module DecidimHospitalet
         end
 
         def user
-          return unless form.email.present?
+          return default_user unless form.email.present?
           return @user if @user
           @user ||= existing_user || invited_user
         end
@@ -85,6 +85,13 @@ module DecidimHospitalet
         def existing_user
           Decidim::User.where(
             email: form.email,
+            organization: form.current_feature.organization
+          ).first
+        end
+
+        def default_user
+          Decidim::User.where(
+            email: "enquestes@lhon-participa.cat",
             organization: form.current_feature.organization
           ).first
         end

--- a/engines/decidim_hospitalet-surveys/spec/commands/decidim_hospitalet/surveys/admin/create_survey_result_spec.rb
+++ b/engines/decidim_hospitalet-surveys/spec/commands/decidim_hospitalet/surveys/admin/create_survey_result_spec.rb
@@ -144,19 +144,24 @@ module DecidimHospitalet
               end
 
               context "when not creating a user" do
+                let!(:default_user) do
+                  create :user,
+                    email: "enquestes@lhon-participa.cat",
+                    organization: organization
+                end
+
                 let(:email) { nil }
 
-                it "creates anonymous proposals" do
+                it "assigns the proposal to the fake user 'Enquesta / Encuesta'" do
                   subject.call
                   proposals = Decidim::Proposals::Proposal.all
 
-                  expect(proposals.map(&:author)).to eq [nil, nil]
+                  expect(proposals.map(&:author)).to eq [default_user, default_user]
                 end
               end
 
               context "when creating a user" do
                 let(:email) { "my_email@example.com" }
-
                 it "assigns the proposals to the user" do
                   subject.call
                   authors = Decidim::Proposals::Proposal.all.map(&:author)


### PR DESCRIPTION
### :tophat: What? Why?
This PR adds a migration to generate a fake user with ```enquestes@lhon-participa.cat``` as email, that would work as a author for those proposals that aren't filled without an associated to an email.

Also the PR includes the necessary migration for the data at production: all proposals that don't have an author should be assigned to this fake user.

#### :pushpin: Related Issues
- Fixes #124

#### :clipboard: Subtasks
- [X] Create migration with a new ```Enquesta / Encuesta``` user and update old proposals.
- [X] Update create_survey_result 
- [X] Specs

### :camera: Screenshots (optional)
<img width="941" alt="screen shot 2017-02-23 at 15 40 49" src="https://cloud.githubusercontent.com/assets/953911/23263667/342cddb4-f9df-11e6-9305-40f889d51cf8.png">

#### :ghost: GIF
![](https://media.giphy.com/media/5xtDarEbygs3Pu7p3jO/giphy.gif)
