### PR TITLE
Add name validation if email exists

### DIFF
--- a/engines/decidim_hospitalet-surveys/app/forms/decidim_hospitalet/surveys/admin/survey_result_form.rb
+++ b/engines/decidim_hospitalet-surveys/app/forms/decidim_hospitalet/surveys/admin/survey_result_form.rb
@@ -21,6 +21,7 @@ module DecidimHospitalet
         attribute :phone, String
         attribute :email, String
 
+        validates :name, presence: true, if: proc { |form| form.email.present? }
         validates :scope, :scope_id, presence: true
         validates :categories, :categories_ids, length: { minimum: 1, maximum: 4 }
         validates :age_group, inclusion: { in: SurveyResult::AGE_GROUPS }, allow_blank: true

--- a/engines/decidim_hospitalet-surveys/spec/forms/decidim_hospitalet/surveys/admin/survey_form_spec.rb
+++ b/engines/decidim_hospitalet-surveys/spec/forms/decidim_hospitalet/surveys/admin/survey_form_spec.rb
@@ -233,6 +233,20 @@ module DecidimHospitalet
             it { is_expected.not_to be_valid }
           end
         end
+
+        describe "name" do
+          context "exists when the email isn't present" do
+            let(:params) do
+              default_params.merge(
+                name: "",
+                email: "test@lhon-participa.cat"
+              )
+            end
+            it { is_expected.not_to be_valid }
+          end
+
+        end
+
       end
     end
   end

--- a/engines/decidim_hospitalet-surveys/spec/forms/decidim_hospitalet/surveys/admin/survey_form_spec.rb
+++ b/engines/decidim_hospitalet-surveys/spec/forms/decidim_hospitalet/surveys/admin/survey_form_spec.rb
@@ -235,7 +235,7 @@ module DecidimHospitalet
         end
 
         describe "name" do
-          context "exists when the email isn't present" do
+          context "when the email isn't present" do
             let(:params) do
               default_params.merge(
                 name: "",

--- a/engines/decidim_hospitalet-surveys/spec/forms/decidim_hospitalet/surveys/admin/survey_form_spec.rb
+++ b/engines/decidim_hospitalet-surveys/spec/forms/decidim_hospitalet/surveys/admin/survey_form_spec.rb
@@ -244,9 +244,7 @@ module DecidimHospitalet
             end
             it { is_expected.not_to be_valid }
           end
-
         end
-
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a validation on the name depending on the presence of the email when a user answer a survey.

#### :pushpin: Related Issues
- Fixes #129

#### :ghost: GIF
![](https://media.giphy.com/media/42YlR8u9gV5Cw/giphy.gif)
