### PR TITLE
Add missing property to geocoder config

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -10,6 +10,7 @@ Decidim.configure do |config|
 
   if Rails.application.secrets.geocoder
     config.geocoder = {
+      static_map_url: "https://image.maps.cit.api.here.com/mia/1.6/mapview",
       here_app_id: Rails.application.secrets.geocoder["here_app_id"],
       here_app_code: Rails.application.secrets.geocoder["here_app_code"]
     }


### PR DESCRIPTION
#### :tophat: What? Why?

Add missing configuration property to `geocoder`.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
