### PR TITLE
Add Raven context

### DIFF
--- a/app/controllers/decidim_controller.rb
+++ b/app/controllers/decidim_controller.rb
@@ -1,2 +1,9 @@
 class DecidimController < ApplicationController
+  before_action :set_raven_context
+
+  def set_raven_context
+    return unless Rails.application.secrets.sentry_enabled?
+    Raven.user_context({id: try(:current_user).try(:id)}.merge(session))
+    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
+  end
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,6 +11,7 @@
 # if you're sharing your code publicly.
 
 default: &default
+  sentry_enabled: false
   omniauth:
     facebook:
       enabled: <%= !ENV["OMNIAUTH_FACEBOOK_APP_ID"].blank? %>
@@ -40,6 +41,7 @@ test:
 # instead read values from the environment.
 production:
   <<: *default
+  sentry_enabled: true
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   sendgrid: <%= !ENV["SENDGRID_USERNAME"].blank? %>
   smtp_username: <%= ENV["SMTP_USERNAME"] || ENV["SENDGRID_USERNAME"] %>


### PR DESCRIPTION
#### :tophat: What? Why?
This adds context to our Sentry error reports.

#### :ghost: GIF
![](https://media.giphy.com/media/SRO0ZwmImic0/giphy.gif)