### PR TITLE
Fix sidekiq admin route constraint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
-  authenticate :user, lambda { |u| u.roles.include?("admin") } do
+  authenticate :user, lambda { |u| u.admin? } do
     mount Sidekiq::Web => '/sidekiq'
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

The sidekiq admin route was broken because `admin` is no longer a role since https://github.com/decidim/decidim/pull/1605

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/pull/1605

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
None
