### PR TITLE
Update registration form to work with Decidim 0.9

### DIFF
--- a/app/views/decidim/devise/registrations/new.html.erb
+++ b/app/views/decidim/devise/registrations/new.html.erb
@@ -44,7 +44,7 @@
 
               <fieldset>
                 <div class="field">
-                  <%= f.check_box :newsletter_notifications, label: t(".newsletter_notifications") %>
+                  <%= f.check_box :newsletter, label: t(".newsletter"), checked: true %>
                 </div>
 
                 <div class="field">


### PR DESCRIPTION
#### :tophat: What? Why?

The registration form has to be updated since it doesn't have the user group option.

#### :pushpin: Related Issues
- Fixes https://sentry.io/share/issue/7748c2d6d7254ea5b6fcf6cc444bc30f/
