### PR TITLE
Simplify migration

### DIFF
--- a/db/migrate/20201130123057_move_proposals_fields_to_i18n.decidim_proposals.rb
+++ b/db/migrate/20201130123057_move_proposals_fields_to_i18n.decidim_proposals.rb
@@ -13,9 +13,7 @@ class MoveProposalsFieldsToI18n < ActiveRecord::Migration[5.2]
         author = proposal.coauthorships.first.author
 
         locale = if author
-                   author.try(:locale).presence || author.try(:default_locale).presence || author.try(:organization).try(:default_locale).presence
-                 elsif proposal.component && proposal.component.participatory_space
-                   proposal.component.participatory_space.organization.default_locale
+                   author.locale.presence || author.default_locale.presence
                  else
                    I18n.default_locale.to_s
                  end


### PR DESCRIPTION
#### :tophat: What? Why?
Simplify migration because it's taking too long. This installation only has 1 organization, so we can simplify some things.

