### PR TITLE
Add online meetings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 ruby RUBY_VERSION
-DECIDIM_VERSION = { git: "https://github.com/decidim/decidim", tag: "release/0.23-stable" }
+DECIDIM_VERSION = { git: "https://github.com/HospitaletDeLlobregat/decidim", tag: "feat/v0.23-with-online-meetings" }
 
 gem "decidim", DECIDIM_VERSION
 gem "geocoder", "~> 1.6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,7 @@
 GIT
-  remote: https://github.com/Platoniq/decidim-verifications-direct_verifications.git
-  revision: 33314fb9136353942d6d2cbddcc9fd257045953f
-  specs:
-    decidim-direct_verifications (0.20)
-      decidim-admin (>= 0.17.0)
-      decidim-core (>= 0.17.0)
-
-GIT
-  remote: https://github.com/alabs/decidim-module-calendar.git
-  revision: 929739b916c624b471a326569ac53802c79e6aaf
-  specs:
-    decidim-calendar (0.19.0)
-      decidim-admin (>= 0.19.0)
-      decidim-core (>= 0.19.0)
-
-GIT
-  remote: https://github.com/decidim/decidim
-  revision: adc6459b0ac729613534ca8a1e8326d26aafbd2f
-  tag: release/0.23-stable
+  remote: https://github.com/HospitaletDeLlobregat/decidim
+  revision: e959630dc5c373849397a90180641da90f88926a
+  tag: feat/v0.23-with-online-meetings
   specs:
     decidim (0.23.1)
       decidim-accountability (= 0.23.1)
@@ -215,6 +199,22 @@ GIT
       sassc-rails (~> 2.1.2)
     decidim-verifications (0.23.1)
       decidim-core (= 0.23.1)
+
+GIT
+  remote: https://github.com/Platoniq/decidim-verifications-direct_verifications.git
+  revision: 33314fb9136353942d6d2cbddcc9fd257045953f
+  specs:
+    decidim-direct_verifications (0.20)
+      decidim-admin (>= 0.17.0)
+      decidim-core (>= 0.17.0)
+
+GIT
+  remote: https://github.com/alabs/decidim-module-calendar.git
+  revision: 929739b916c624b471a326569ac53802c79e6aaf
+  specs:
+    decidim-calendar (0.19.0)
+      decidim-admin (>= 0.19.0)
+      decidim-core (>= 0.19.0)
 
 GEM
   remote: https://rubygems.org/

--- a/db/migrate/20201203093622_add_online_meeting_url.decidim_meetings.rb
+++ b/db/migrate/20201203093622_add_online_meeting_url.decidim_meetings.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_meetings (originally 20201006140511)
+
+class AddOnlineMeetingUrl < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_meetings_meetings, :online_meeting_url, :string
+  end
+end

--- a/db/migrate/20201203093623_add_type_of_meeting.decidim_meetings.rb
+++ b/db/migrate/20201203093623_add_type_of_meeting.decidim_meetings.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_meetings (originally 20201009124057)
+
+class AddTypeOfMeeting < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_meetings_meetings, :type_of_meeting, :string, default: "in_person"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_30_123077) do
+ActiveRecord::Schema.define(version: 2020_12_03_093623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -802,6 +802,8 @@ ActiveRecord::Schema.define(version: 2020_11_30_123077) do
     t.string "decidim_author_type"
     t.integer "decidim_user_group_id"
     t.integer "comments_count", default: 0, null: false
+    t.string "online_meeting_url"
+    t.string "type_of_meeting", default: "in_person"
     t.index ["decidim_author_id", "decidim_author_type"], name: "index_decidim_meetings_meetings_on_author"
     t.index ["decidim_author_id"], name: "index_decidim_meetings_meetings_on_decidim_author_id"
     t.index ["decidim_component_id"], name: "index_decidim_meetings_meetings_on_decidim_component_id"


### PR DESCRIPTION
#### :tophat: What? Why?
Online meetings will be officially released in Decidim's v0.24. This PR points to a fork of Decidim to enable the activation of online meetings in our current version: 0.23-stable. 

#### :pushpin: Related Issues
- Related to this [ClickUp's task](https://app.clickup.com/t/agxbc7)

#### :clipboard: Subtasks
- [x] Forks Decidim and adds online meeting to v0.23-stable
- [x] Adds migratios

