### PR TITLE
Update to Decidim 0.23-stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 ruby RUBY_VERSION
-DECIDIM_VERSION = { git: "https://github.com/HospitaletDeLlobregat/decidim", tag: "feat/v0.23-with-online-meetings" }
+DECIDIM_VERSION = { git: "https://github.com/decidim/decidim", tag: "release/0.23-stable" }
 
 gem "decidim", DECIDIM_VERSION
 gem "geocoder", "~> 1.6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,23 @@
 GIT
-  remote: https://github.com/HospitaletDeLlobregat/decidim
-  revision: adf87d76ac965c51f8c38b4094427f027c4e90ed
-  tag: feat/v0.23-with-online-meetings
+  remote: https://github.com/Platoniq/decidim-verifications-direct_verifications.git
+  revision: 33314fb9136353942d6d2cbddcc9fd257045953f
+  specs:
+    decidim-direct_verifications (0.20)
+      decidim-admin (>= 0.17.0)
+      decidim-core (>= 0.17.0)
+
+GIT
+  remote: https://github.com/alabs/decidim-module-calendar.git
+  revision: 929739b916c624b471a326569ac53802c79e6aaf
+  specs:
+    decidim-calendar (0.19.0)
+      decidim-admin (>= 0.19.0)
+      decidim-core (>= 0.19.0)
+
+GIT
+  remote: https://github.com/decidim/decidim
+  revision: 75f81f1e0577fe9ddc94ee14e134a594647a8ad3
+  tag: release/0.23-stable
   specs:
     decidim (0.23.1)
       decidim-accountability (= 0.23.1)
@@ -200,22 +216,6 @@ GIT
     decidim-verifications (0.23.1)
       decidim-core (= 0.23.1)
 
-GIT
-  remote: https://github.com/Platoniq/decidim-verifications-direct_verifications.git
-  revision: 33314fb9136353942d6d2cbddcc9fd257045953f
-  specs:
-    decidim-direct_verifications (0.20)
-      decidim-admin (>= 0.17.0)
-      decidim-core (>= 0.17.0)
-
-GIT
-  remote: https://github.com/alabs/decidim-module-calendar.git
-  revision: 929739b916c624b471a326569ac53802c79e6aaf
-  specs:
-    decidim-calendar (0.19.0)
-      decidim-admin (>= 0.19.0)
-      decidim-core (>= 0.19.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -317,7 +317,7 @@ GEM
       actionpack (>= 3.0)
       cells (>= 4.1.6, < 5.0.0)
     charlock_holmes (0.7.7)
-    chef-utils (16.7.61)
+    chef-utils (16.9.17)
     childprocess (3.0.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -330,7 +330,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.7)
     connection_pool (2.2.3)
-    crack (0.4.4)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     css_parser (1.7.1)
       addressable
@@ -367,7 +368,7 @@ GEM
     doc2text (0.4.2)
       nokogiri (~> 1.10.0)
       rubyzip (~> 2.0.0)
-    docile (1.3.2)
+    docile (1.3.4)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     doorkeeper (5.4.0)
@@ -376,12 +377,13 @@ GEM
     emd (0.1.0)
       redcarpet
     equalizer (0.0.11)
-    erb_lint (0.0.30)
+    erb_lint (0.0.37)
       activesupport
       better_html (~> 1.0.7)
       html_tokenizer
+      parser (>= 2.7.1.4)
       rainbow
-      rubocop (~> 0.51)
+      rubocop
       smart_properties
     erbse (0.1.4)
       temple
@@ -451,7 +453,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    i18n-tasks (0.9.31)
+    i18n-tasks (0.9.33)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       erubi
@@ -549,16 +551,17 @@ GEM
       rack (>= 1.6.2, < 3)
     omniauth-facebook (5.0.0)
       omniauth-oauth2 (~> 1.2)
-    omniauth-google-oauth2 (0.8.0)
+    omniauth-google-oauth2 (0.8.1)
       jwt (>= 2.0)
+      oauth2 (~> 1.1)
       omniauth (>= 1.1.1)
       omniauth-oauth2 (>= 1.6)
     omniauth-oauth (1.1.0)
       oauth
       omniauth (~> 1.0)
-    omniauth-oauth2 (1.7.0)
+    omniauth-oauth2 (1.7.1)
       oauth2 (~> 1.4)
-      omniauth (~> 1.9)
+      omniauth (>= 1.9, < 3)
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
@@ -768,7 +771,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tomlrb (2.0.0)
+    tomlrb (2.0.1)
     truncato (0.7.11)
       htmlentities (~> 4.3.1)
       nokogiri (>= 1.7.0, <= 2.0)
@@ -793,7 +796,7 @@ GEM
       virtus (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webmock (3.10.0)
+    webmock (3.11.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)


### PR DESCRIPTION
#### :tophat: What? Why?

We no longer need to use the temporary fork.
